### PR TITLE
Make @Rule fields public

### DIFF
--- a/src/main/java/examples/junit/RepeatingTest.java
+++ b/src/main/java/examples/junit/RepeatingTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
 public class RepeatingTest {
 
   @Rule
-  RepeatRule rule = new RepeatRule();
+  public RepeatRule rule = new RepeatRule();
 
   @Repeat(1000)
   @Test

--- a/src/main/java/examples/junit/RunOnContextJUnitTestSuite.java
+++ b/src/main/java/examples/junit/RunOnContextJUnitTestSuite.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
 public class RunOnContextJUnitTestSuite {
 
   @Rule
-  RunTestOnContext rule = new RunTestOnContext();
+  public RunTestOnContext rule = new RunTestOnContext();
 
   @Test
   public void testSomething(TestContext context) {


### PR DESCRIPTION
Without this, JUnit can fail during initialization without an explanation.