### PR TITLE
timeouts are longs

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -854,7 +854,7 @@ import org.junit.Test;
 
 public class JunitTestWithTimeout {
 
-  @Test(timeout = 1000)
+  @Test(timeout = 1000l)
   public void testSomething(TestContext context) {
     //...
   }

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -789,7 +789,7 @@ import org.junit.Test;
 
 public class JunitTestWithTimeout {
 
-  @Test(timeout = 1000)
+  @Test(timeout = 1000l)
   public void testSomething(TestContext context) {
     //...
   }

--- a/src/main/java/examples/junit/JunitTestWithTimeout.java
+++ b/src/main/java/examples/junit/JunitTestWithTimeout.java
@@ -6,7 +6,7 @@ import org.junit.Test;
 
 public class JunitTestWithTimeout {
 
-  @Test(timeout = 1000)
+  @Test(timeout = 1000l)
   public void testSomething(TestContext context) {
     //...
   }


### PR DESCRIPTION
I got an error in Eclipse yesterday while typing : 

```groovy
@Test(timeout = 1000)
void testSomething(TestContext context) {
}
```

Telling me that timeouts should be long. 

I guess the doc should be updated for Groovy & Java (Ruby too maybe ? idk :( )