### PR TITLE
CLI "vertx test" not reporting failed tests to exit status code

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -663,7 +663,7 @@ suite.run()
 
 The `vertx test` command extends the `vertx run` command. The exit behavior of the JVM is changed
 the JVM exits when the test suite is executed and a return value is provided indicating the tests
-success (0) or failure (1).
+success (0) or failure (n) where `n` is >=1 and represents the total number of failed tests.
 
 NOTE: several test suites can executed in the same verticle, Vert.x Unit waits until completion of
 all suite executed.

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -618,7 +618,7 @@ suite.run();
 
 The `vertx test` command extends the `vertx run` command. The exit behavior of the JVM is changed
 the JVM exits when the test suite is executed and a return value is provided indicating the tests
-success (0) or failure (1).
+success (0) or failure (n) where `n` is >=1 and represents the total number of failed tests.
 
 NOTE: several test suites can executed in the same verticle, Vert.x Unit waits until completion of
 all suite executed.

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -663,7 +663,7 @@ suite.run();
 
 The `vertx test` command extends the `vertx run` command. The exit behavior of the JVM is changed
 the JVM exits when the test suite is executed and a return value is provided indicating the tests
-success (0) or failure (1).
+success (0) or failure (n) where `n` is >=1 and represents the total number of failed tests.
 
 NOTE: several test suites can executed in the same verticle, Vert.x Unit waits until completion of
 all suite executed.

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -663,7 +663,7 @@ suite.run()
 
 The `vertx test` command extends the `vertx run` command. The exit behavior of the JVM is changed
 the JVM exits when the test suite is executed and a return value is provided indicating the tests
-success (0) or failure (1).
+success (0) or failure (n) where `n` is >=1 and represents the total number of failed tests.
 
 NOTE: several test suites can executed in the same verticle, Vert.x Unit waits until completion of
 all suite executed.

--- a/src/main/java/io/vertx/ext/unit/impl/TestCommand.java
+++ b/src/main/java/io/vertx/ext/unit/impl/TestCommand.java
@@ -4,7 +4,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.cli.annotations.DefaultValue;
 import io.vertx.core.cli.annotations.Description;
 import io.vertx.core.cli.annotations.Name;
 import io.vertx.core.cli.annotations.Option;
@@ -128,10 +127,14 @@ public class TestCommand extends RunCommand {
 
     // Now wait each completion
     TestCompletionImpl completion;
+    int remainingCompletions = completions.size();
     while ((completion = completions.poll()) != null) {
       completion.await();
+      if(completion.isSucceeded()) {
+        remainingCompletions--;
+      }
     }
-    System.exit(0);
+    System.exit(remainingCompletions);
   }
 
   @Override


### PR DESCRIPTION
inspect the completion status and exit with the appropriate code