### PR TITLE
Updated doc on use of Hamcrest, AssertJ, fixed broken link

### DIFF
--- a/src/main/asciidoc/groovy/index.adoc
+++ b/src/main/asciidoc/groovy/index.adoc
@@ -19,7 +19,7 @@ To use vert.x unit, add the following dependency to the _dependencies_ section o
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-unit</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -27,7 +27,7 @@ To use vert.x unit, add the following dependency to the _dependencies_ section o
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-unit:3.3.0
+compile io.vertx:vertx-unit:3.3.1-SNAPSHOT
 ----
 
 Vert.x unit can be used in different ways and run anywhere your code runs, it is just a matter of reporting
@@ -629,7 +629,7 @@ suite.run(vertx)
 
 ----
 
-When running with a `Vertx` instance, the test suite is executed using the Vertx event loop, see the <<eventloop>>
+When running with a `Vertx` instance, the test suite is executed using the Vertx event loop, see the <<event_loop>>
 section for more details.
 
 A test suite can be run with the Vert.x Command Line Interface with the `vertx test` command:
@@ -882,6 +882,7 @@ collector.register("the-address")
 
 ----
 
+[[vertx_integration]]
 == Vertx integration
 
 By default, assertions and failures must be done on the `link:../../groovydoc/io/vertx/groovy/ext/unit/TestContext.html[TestContext]` and throwing an
@@ -1154,6 +1155,16 @@ public class RepeatingTest {
 When declared, _before_ and _after_ life cycle will be executed as many times as the test is executed.
 
 NOTE: test repetition are executed sequentially
+
+=== Using with other assertion libraries
+
+Vert.x Unit usability has been greatly improved in Vert.x 3.3. You can now write tests using 
+http://hamcrest.org/[Hamcrest], http://joel-costigliola.github.io/assertj/[AssertJ],
+https://github.com/rest-assured/rest-assured/[Rest Assured], or any assertion library you want. This is made 
+possible by the global exception handler described in <<vertx_integration>>.
+
+You can find Java examples of using Vert.x Unit with Hamcrest and AssertJ in the 
+https://github.com/vert-x3/vertx-examples/tree/master/unit-examples[vertx-examples] project.
 
 == Java language integration
 

--- a/src/main/asciidoc/java/index.adoc
+++ b/src/main/asciidoc/java/index.adoc
@@ -19,7 +19,7 @@ To use vert.x unit, add the following dependency to the _dependencies_ section o
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-unit</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -27,7 +27,7 @@ To use vert.x unit, add the following dependency to the _dependencies_ section o
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-unit:3.3.0
+compile io.vertx:vertx-unit:3.3.1-SNAPSHOT
 ----
 
 Vert.x unit can be used in different ways and run anywhere your code runs, it is just a matter of reporting
@@ -586,7 +586,7 @@ The test suite can also be run with a specified `link:../../apidocs/io/vertx/cor
 suite.run(vertx);
 ----
 
-When running with a `Vertx` instance, the test suite is executed using the Vertx event loop, see the <<eventloop>>
+When running with a `Vertx` instance, the test suite is executed using the Vertx event loop, see the <<event_loop>>
 section for more details.
 
 A test suite can be run with the Vert.x Command Line Interface with the `vertx test` command:
@@ -817,6 +817,7 @@ EventBusCollector collector = EventBusCollector.create(
 collector.register("the-address");
 ----
 
+[[vertx_integration]]
 == Vertx integration
 
 By default, assertions and failures must be done on the `link:../../apidocs/io/vertx/ext/unit/TestContext.html[TestContext]` and throwing an
@@ -1085,6 +1086,16 @@ public class RepeatingTest {
 When declared, _before_ and _after_ life cycle will be executed as many times as the test is executed.
 
 NOTE: test repetition are executed sequentially
+
+=== Using with other assertion libraries
+
+Vert.x Unit usability has been greatly improved in Vert.x 3.3. You can now write tests using 
+http://hamcrest.org/[Hamcrest], http://joel-costigliola.github.io/assertj/[AssertJ],
+https://github.com/rest-assured/rest-assured/[Rest Assured], or any assertion library you want. This is made 
+possible by the global exception handler described in <<vertx_integration>>.
+
+You can find Java examples of using Vert.x Unit with Hamcrest and AssertJ in the 
+https://github.com/vert-x3/vertx-examples/tree/master/unit-examples[vertx-examples] project.
 
 == Java language integration
 

--- a/src/main/asciidoc/js/index.adoc
+++ b/src/main/asciidoc/js/index.adoc
@@ -19,7 +19,7 @@ To use vert.x unit, add the following dependency to the _dependencies_ section o
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-unit</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -27,7 +27,7 @@ To use vert.x unit, add the following dependency to the _dependencies_ section o
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-unit:3.3.0
+compile io.vertx:vertx-unit:3.3.1-SNAPSHOT
 ----
 
 Vert.x unit can be used in different ways and run anywhere your code runs, it is just a matter of reporting
@@ -629,7 +629,7 @@ suite.run(vertx);
 
 ----
 
-When running with a `Vertx` instance, the test suite is executed using the Vertx event loop, see the <<eventloop>>
+When running with a `Vertx` instance, the test suite is executed using the Vertx event loop, see the <<event_loop>>
 section for more details.
 
 A test suite can be run with the Vert.x Command Line Interface with the `vertx test` command:
@@ -882,6 +882,7 @@ collector.register("the-address");
 
 ----
 
+[[vertx_integration]]
 == Vertx integration
 
 By default, assertions and failures must be done on the `link:../../jsdoc/module-vertx-unit-js_test_context-TestContext.html[TestContext]` and throwing an
@@ -1154,6 +1155,16 @@ public class RepeatingTest {
 When declared, _before_ and _after_ life cycle will be executed as many times as the test is executed.
 
 NOTE: test repetition are executed sequentially
+
+=== Using with other assertion libraries
+
+Vert.x Unit usability has been greatly improved in Vert.x 3.3. You can now write tests using 
+http://hamcrest.org/[Hamcrest], http://joel-costigliola.github.io/assertj/[AssertJ],
+https://github.com/rest-assured/rest-assured/[Rest Assured], or any assertion library you want. This is made 
+possible by the global exception handler described in <<vertx_integration>>.
+
+You can find Java examples of using Vert.x Unit with Hamcrest and AssertJ in the 
+https://github.com/vert-x3/vertx-examples/tree/master/unit-examples[vertx-examples] project.
 
 == Java language integration
 

--- a/src/main/asciidoc/ruby/index.adoc
+++ b/src/main/asciidoc/ruby/index.adoc
@@ -19,7 +19,7 @@ To use vert.x unit, add the following dependency to the _dependencies_ section o
 <dependency>
   <groupId>io.vertx</groupId>
   <artifactId>vertx-unit</artifactId>
-  <version>3.3.0</version>
+  <version>3.3.1-SNAPSHOT</version>
 </dependency>
 ----
 
@@ -27,7 +27,7 @@ To use vert.x unit, add the following dependency to the _dependencies_ section o
 
 [source,groovy,subs="+attributes"]
 ----
-compile io.vertx:vertx-unit:3.3.0
+compile io.vertx:vertx-unit:3.3.1-SNAPSHOT
 ----
 
 Vert.x unit can be used in different ways and run anywhere your code runs, it is just a matter of reporting
@@ -629,7 +629,7 @@ suite.run(vertx)
 
 ----
 
-When running with a `Vertx` instance, the test suite is executed using the Vertx event loop, see the <<eventloop>>
+When running with a `Vertx` instance, the test suite is executed using the Vertx event loop, see the <<event_loop>>
 section for more details.
 
 A test suite can be run with the Vert.x Command Line Interface with the `vertx test` command:
@@ -882,6 +882,7 @@ collector.register("the-address")
 
 ----
 
+[[vertx_integration]]
 == Vertx integration
 
 By default, assertions and failures must be done on the `link:../../yardoc/VertxUnit/TestContext.html[TestContext]` and throwing an
@@ -1154,6 +1155,16 @@ public class RepeatingTest {
 When declared, _before_ and _after_ life cycle will be executed as many times as the test is executed.
 
 NOTE: test repetition are executed sequentially
+
+=== Using with other assertion libraries
+
+Vert.x Unit usability has been greatly improved in Vert.x 3.3. You can now write tests using 
+http://hamcrest.org/[Hamcrest], http://joel-costigliola.github.io/assertj/[AssertJ],
+https://github.com/rest-assured/rest-assured/[Rest Assured], or any assertion library you want. This is made 
+possible by the global exception handler described in <<vertx_integration>>.
+
+You can find Java examples of using Vert.x Unit with Hamcrest and AssertJ in the 
+https://github.com/vert-x3/vertx-examples/tree/master/unit-examples[vertx-examples] project.
 
 == Java language integration
 

--- a/src/main/java/io/vertx/ext/unit/package-info.java
+++ b/src/main/java/io/vertx/ext/unit/package-info.java
@@ -349,7 +349,7 @@
  * {@link examples.Examples#running_02}
  * ----
  *
- * When running with a `Vertx` instance, the test suite is executed using the Vertx event loop, see the <<eventloop>>
+ * When running with a `Vertx` instance, the test suite is executed using the Vertx event loop, see the <<event_loop>>
  * section for more details.
  *
  * A test suite can be run with the Vert.x Command Line Interface with the `vertx test` command:
@@ -537,6 +537,7 @@
  * {@link examples.Examples#reporter_02}
  * ----
  *
+ * [[vertx_integration]]
  * == Vertx integration
  *
  * By default, assertions and failures must be done on the {@link io.vertx.ext.unit.TestContext} and throwing an
@@ -661,6 +662,16 @@
  * When declared, _before_ and _after_ life cycle will be executed as many times as the test is executed.
  *
  * NOTE: test repetition are executed sequentially
+ *
+ * === Using with other assertion libraries
+ *
+ * Vert.x Unit usability has been greatly improved in Vert.x 3.3. You can now write tests using 
+ * http://hamcrest.org/[Hamcrest], http://joel-costigliola.github.io/assertj/[AssertJ],
+ * https://github.com/rest-assured/rest-assured/[Rest Assured], or any assertion library you want. This is made 
+ * possible by the global exception handler described in <<vertx_integration>>.
+ *
+ * You can find Java examples of using Vert.x Unit with Hamcrest and AssertJ in the 
+ * https://github.com/vert-x3/vertx-examples/tree/master/unit-examples[vertx-examples] project.
  *
  * == Java language integration
  *


### PR DESCRIPTION
Once again thanks for the information provided in #8 

I wasn't aware these examples existed already in vertx-examples and spend some time looking around.
So I have taken the freedom to add some reference to the documentation to help others get around quicker.

Also fixed a broken link to the [[event_loop]] paragraph.