### PR TITLE
Allow to define a global repeat mode per tests classes

### DIFF
--- a/src/main/java/examples/junit/RepeatingTest.java
+++ b/src/main/java/examples/junit/RepeatingTest.java
@@ -9,14 +9,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(VertxUnitRunner.class)
+@Repeat(10)
 public class RepeatingTest {
 
   @Rule
   public RepeatRule rule = new RepeatRule();
 
-  @Repeat(1000)
+  @Repeat(value = 1000, silent = true)
   @Test
-  public void testSomething(TestContext context) {
-    // This will be executed 1000 times
+  public void testSomethingWithSpecificRepeat(final TestContext context) {
+    // This will be executed 1000 times in silent mode
+  }
+  
+  public void testSomethingWithDefaultConfig(final TestContext context) {
+      // This will be executed 10 times with a message per iteration
   }
 }

--- a/src/main/java/io/vertx/ext/unit/junit/Repeat.java
+++ b/src/main/java/io/vertx/ext/unit/junit/Repeat.java
@@ -1,8 +1,6 @@
 package io.vertx.ext.unit.junit;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 /**
  * Annotates a test method to repeat this test several times. This can be useful when a test fails randomly and
@@ -11,7 +9,7 @@ import java.lang.annotation.Target;
  * @author <a href="http://tfox.org">Tim Fox</a>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({java.lang.annotation.ElementType.METHOD})
+@Target({ElementType.METHOD, ElementType.TYPE})
 public @interface Repeat {
 
   int value();

--- a/src/main/java/io/vertx/ext/unit/junit/RepeatRule.java
+++ b/src/main/java/io/vertx/ext/unit/junit/RepeatRule.java
@@ -37,10 +37,11 @@ public class RepeatRule implements TestRule {
   @Override
   public Statement apply( Statement statement, Description description ) {
     Statement result = statement;
-    Repeat repeat = description.getAnnotation(Repeat.class);
-    if( repeat != null ) {
-      final int times = repeat.value();
-      final boolean silent = repeat.silent();
+    final Repeat global = description.getTestClass().getAnnotation(Repeat.class);
+    final Repeat local = description.getAnnotation(Repeat.class);
+    if( local != null || global != null ) {
+      final int times = local != null ? local.value() : global.value();
+      final boolean silent = local != null ? local.silent() : global.silent();
       result = new RepeatStatement(times, statement, description, silent);
     }
     return result;


### PR DESCRIPTION
This pull request allow to define a global repeat behaviour mode : 

```java
@RunWith(VertxUnitRunner.class)
@Repeat(value = AsyncUtilsTest.REPEAT_LIMIT, silent = true)
public final class AsyncUtilsTest {

    /**
     * Limits
     */
    private static final int TIMEOUT_LIMIT = 1500;
    static final int REPEAT_LIMIT = 100;

    @Rule
    public RepeatRule repeater = new RepeatRule();
    @Rule
    public RunTestOnContext rule = new RunTestOnContext();

    @Test(timeout = AsyncUtilsTest.TIMEOUT_LIMIT)
    public void timeoutNotRaised(final TestContext context) {
        //.....
    }

    @Test(timeout = AsyncUtilsTest.TIMEOUT_LIMIT)
    public void timeoutNotRaisedWithError(final TestContext context) {
        //.....
    }

    @Test(timeout = AsyncUtilsTest.TIMEOUT_LIMIT)
    public void timeoutRaised(final TestContext context) {
        //.....
    }

    @Test(timeout = AsyncUtilsTest.TIMEOUT_LIMIT)
    public void timeoutRaisedWithError(final TestContext context) {
        //.....
    }

    @Test(timeout = AsyncUtilsTest.TIMEOUT_LIMIT)
    @Repeat(value = 1, silent = true)
    public void createMemoize(final TestContext context) {
        // 1 repeat in silent mode
    }

    @Test(timeout = AsyncUtilsTest.TIMEOUT_LIMIT)
    public void constantWithNull(final TestContext context) {
        //.....
    }
    @Test(timeout = AsyncUtilsTest.TIMEOUT_LIMIT)
    public void asyncifyAFunction(final TestContext context) {
        //.....
    }
}
```