### PR TITLE
Fix multiple async complete calls

### DIFF
--- a/src/main/java/io/vertx/ext/unit/impl/TestContextImpl.java
+++ b/src/main/java/io/vertx/ext/unit/impl/TestContextImpl.java
@@ -160,7 +160,7 @@ public class TestContextImpl implements TestContext {
         if (value > 0) {
           completable.complete(null);
           internalComplete();
-        } else if (value < 0) {
+        } else {
           throw new IllegalStateException("The Async complete method has been called more than " + initialCount + " times, check your test.");
         }
       }

--- a/src/test/java/io/vertx/ext/unit/impl/TestContextImplTest.java
+++ b/src/test/java/io/vertx/ext/unit/impl/TestContextImplTest.java
@@ -1,0 +1,32 @@
+package io.vertx.ext.unit.impl;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.runner.Result;
+import org.junit.runner.JUnitCore;
+
+public final class TestContextImplTest {
+
+    public static class DoubleAsyncCompleteTest {
+
+        @Test
+        public void test(final TestContext context) {
+            final Async async = context.async();
+            async.complete();
+            async.complete();
+        }
+
+    }
+
+    @Test
+    public void testDoubleAsyncComplete() throws Throwable {
+        final Result result = new JUnitCore().run(new VertxUnitRunner(DoubleAsyncCompleteTest.class));
+        assertFalse(result.wasSuccessful());
+        assertEquals(1, result.getFailureCount());
+        assertTrue(result.getFailures().get(0).getException() instanceof IllegalStateException);
+    }
+
+}


### PR DESCRIPTION
This pull request contains a fix when a test unit call more than one time the async complete method : 
```java
        @Test
        public void test(final TestContext context) {
            final Async async = context.async();
            async.complete();
            async.complete(); // Must raised an exception
        }
```