### PR TITLE
Method level timeout overwrites class level timeout

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -642,7 +642,18 @@ For a more global configuration, the {@link io.vertx.ext.unit.junit.Timeout} rul
 {@link examples.junit.TimeoutTestSuite}
 ----
 
-NOTE: the `@Test` timeout overrides the the {@link io.vertx.ext.unit.junit.Timeout} rule.
+NOTE: Use `io.vertx.ext.unit.junit.Timeout`, not `org.junit.rules.Timeout`.
+
+The method level timeout overwrites the class level timeout:
+
+.Combine the class level rule with a method level timeout
+[source,java]
+----
+{@link examples.junit.TimeoutOverwriteTestSuite}
+----
+
+NOTE: The `@Test` timeout overrides the `io.vertx.ext.unit.junit.Timeout` rule but not the
+`org.junit.rules.Timeout` rule.
 
 === Parameterized tests
 

--- a/src/main/java/examples/junit/TimeoutOverwriteTestSuite.java
+++ b/src/main/java/examples/junit/TimeoutOverwriteTestSuite.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+ * which is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+ */
+
+package examples.junit;
+
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.Timeout;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class TimeoutOverwriteTestSuite {
+
+  @Rule
+  public Timeout rule = Timeout.millis(5_000L);
+
+  @Test
+  public void testQuick(TestContext context) {
+    //...
+  }
+
+  @Test(timeout = 30_000L)
+  public void testSlow(TestContext context) {
+    //...
+  }
+}


### PR DESCRIPTION
* Add example with both method and class level timeout to asciidoc.
* Add warning about org.junit.rules.Timeout to asciidoc.
* Add unit test for timeout overwrite.
* Fix timeout unit tests: Replace context.async by sleep.